### PR TITLE
Rewind2 encrypted backups, recovery flow, and inscription chunking

### DIFF
--- a/descriptors/inscriptions/inscriptions.ts
+++ b/descriptors/inscriptions/inscriptions.ts
@@ -15,7 +15,7 @@ import {
 } from 'bitcoinjs-lib';
 import type { PsbtInput } from 'bip174/src/lib/interfaces';
 
-interface PsbtInputExtended extends PsbtInput, PsbtTxInput { }
+interface PsbtInputExtended extends PsbtInput, PsbtTxInput {}
 interface XOnlyPointAddTweakResult {
   parity: 1 | 0;
   xOnlyPubkey: Uint8Array;
@@ -51,6 +51,7 @@ interface TinySecp256k1Interface {
 import { encode, encodingLength } from 'varuint-bitcoin';
 
 const encoder = new TextEncoder();
+const MAX_TAPSCRIPT_ELEMENT_BYTES = 520;
 
 function reverseBuffer(buffer: Buffer): Buffer {
   if (buffer.length < 1) return buffer;
@@ -131,6 +132,18 @@ function createInscriptionScript({
   inscription: InscriptionData;
 }): (number | Buffer)[] {
   const protocolId = Buffer.from(encoder.encode('ord'));
+  const contentChunks: Buffer[] = [];
+  for (
+    let offset = 0;
+    offset < inscription.content.length;
+    offset += MAX_TAPSCRIPT_ELEMENT_BYTES
+  ) {
+    const chunk = inscription.content.subarray(
+      offset,
+      offset + MAX_TAPSCRIPT_ELEMENT_BYTES
+    );
+    contentChunks.push(Buffer.from(chunk));
+  }
 
   return [
     xOnlyPublicKey,
@@ -142,7 +155,7 @@ function createInscriptionScript({
     1,
     Buffer.from(encoder.encode(inscription.contentType)),
     opcodes['OP_0']!,
-    inscription.content,
+    ...contentChunks,
     opcodes['OP_ENDIF']!
   ];
 }

--- a/descriptors/inscriptions/package.json
+++ b/descriptors/inscriptions/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/ledger/package.json
+++ b/descriptors/ledger/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/legacy2segwit/package.json
+++ b/descriptors/legacy2segwit/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/luna/package.json
+++ b/descriptors/luna/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/miniscript/package.json
+++ b/descriptors/miniscript/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/multisig-fallback-timelock/package.json
+++ b/descriptors/multisig-fallback-timelock/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/p2a/package.json
+++ b/descriptors/p2a/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/rewind2/README.md
+++ b/descriptors/rewind2/README.md
@@ -272,9 +272,8 @@ the wallet attach a child transaction later to bump the effective feerate via
 CPFP, without changing the pre‑signed tx. This keeps the pre‑signed path valid
 while still allowing fee adjustment when it's actually needed.
 
-In practice, the trigger/panic are broadcast as pre-signed 0-fee parents. A
-CPFP child spends the P2A anchor and pays the full fee, pulling both into the
-block.
+In practice, the trigger/panic are broadcast as pre-signed 0-fee parents. A CPFP
+child spends the P2A anchor and pays the full fee, pulling both into the block.
 
 ### Anchor Reserve Funding
 
@@ -310,4 +309,8 @@ recommended flow and keeps the demo path intuitive.
 
 ### Backup Encryption
 
-WIP
+The backup payload is encrypted with XChaCha20-Poly1305. The `REW` magic header
+remains plaintext, and the ciphertext includes the 24-byte nonce and 16-byte
+authentication tag. The cipher key is deterministically derived from the wallet
+seed using the vault path (`m/1073'/<network>'/0'/<index>`) via
+`getSeedDerivedCipherKey`, and the AAD is fixed to `Rewind Bitcoin`.

--- a/descriptors/rewind2/backupRecovery.ts
+++ b/descriptors/rewind2/backupRecovery.ts
@@ -89,8 +89,15 @@ const extractOrdinalPayload = (chunks: Array<number | Buffer>) => {
     const item = chunks[i];
     if (Buffer.isBuffer(item) && item.equals(ORD_MARKER)) {
       for (let j = i + 1; j < chunks.length - 1; j += 1) {
-        if (chunks[j] === opcodes['OP_0'] && Buffer.isBuffer(chunks[j + 1])) {
-          return chunks[j + 1] as Buffer;
+        if (chunks[j] === opcodes['OP_0']) {
+          const payloadChunks: Buffer[] = [];
+          for (let k = j + 1; k < chunks.length; k += 1) {
+            const chunk = chunks[k];
+            if (!chunk) break;
+            if (typeof chunk === 'number') break;
+            payloadChunks.push(chunk);
+          }
+          if (payloadChunks.length) return Buffer.concat(payloadChunks);
         }
       }
     }

--- a/descriptors/rewind2/backupRecovery.ts
+++ b/descriptors/rewind2/backupRecovery.ts
@@ -1,0 +1,268 @@
+import { sha256 } from '@noble/hashes/sha2';
+import {
+  Transaction,
+  payments,
+  script as bscript,
+  opcodes,
+  type Network
+} from 'bitcoinjs-lib';
+import { decode as decodeVarInt } from 'varuint-bitcoin';
+import type { Explorer } from '@bitcoinerlab/explorer';
+import { getManagedChacha, getSeedDerivedCipherKey } from './cipher';
+import { getVaultOriginPath } from './vaults';
+import type { BIP32Interface } from 'bip32';
+import { Log, wait } from './utils';
+import { DescriptorsFactory } from '@bitcoinerlab/descriptors';
+import * as secp256k1 from '@bitcoinerlab/secp256k1';
+const { Output } = DescriptorsFactory(secp256k1);
+
+const REW_MAGIC = Buffer.from('REW');
+const ORD_MARKER = Buffer.from('ord');
+const spendingTxCache = new Map<
+  string,
+  { txHex: string; irreversible: boolean; blockHeight: number }
+>();
+
+const transactionFromHex = (txHex: string) => {
+  const tx = Transaction.fromHex(txHex);
+  return { tx, txId: tx.getId() };
+};
+
+const getScriptHash = (script: Buffer) =>
+  Buffer.from(sha256(script)).reverse().toString('hex');
+
+const fetchSpendingTx = async (
+  txHex: string,
+  vout: number,
+  explorer: Explorer
+): Promise<
+  { txHex: string; irreversible: boolean; blockHeight: number } | undefined
+> => {
+  const cacheKey = `${txHex}:${vout}`;
+  const cachedResult = spendingTxCache.get(cacheKey);
+  if (cachedResult && cachedResult.irreversible) return cachedResult;
+
+  const { tx, txId } = transactionFromHex(txHex);
+  const output = tx.outs[vout];
+  if (!output) throw new Error('Invalid output when locating spending tx');
+  const scriptHash = Buffer.from(sha256(output.script))
+    .reverse()
+    .toString('hex');
+
+  const history = await explorer.fetchTxHistory({ scriptHash });
+  for (const txData of history) {
+    const historyTxHex = await explorer.fetchTx(txData.txId);
+    const { tx: historyTx } = transactionFromHex(historyTxHex);
+    const found = historyTx.ins.some(input => {
+      const inputPrevtxId = Buffer.from(input.hash).reverse().toString('hex');
+      return inputPrevtxId === txId && input.index === vout;
+    });
+    if (found) {
+      const spendingTx = {
+        txHex: historyTxHex,
+        irreversible: txData.irreversible,
+        blockHeight: txData.blockHeight
+      };
+      spendingTxCache.set(cacheKey, spendingTx);
+      return spendingTx;
+    }
+  }
+
+  return;
+};
+
+const extractOpReturnPayload = (tx: Transaction) => {
+  for (const output of tx.outs) {
+    try {
+      const embed = payments.embed({ output: output.script });
+      const payload = embed.data?.[0];
+      if (payload && payload.subarray(0, 3).equals(REW_MAGIC)) return payload;
+    } catch {
+      continue;
+    }
+  }
+  return;
+};
+
+const extractOrdinalPayload = (chunks: Array<number | Buffer>) => {
+  for (let i = 0; i < chunks.length - 1; i += 1) {
+    const item = chunks[i];
+    if (Buffer.isBuffer(item) && item.equals(ORD_MARKER)) {
+      for (let j = i + 1; j < chunks.length - 1; j += 1) {
+        if (chunks[j] === opcodes['OP_0'] && Buffer.isBuffer(chunks[j + 1])) {
+          return chunks[j + 1] as Buffer;
+        }
+      }
+    }
+  }
+  return;
+};
+
+const extractInscriptionPayload = (tx: Transaction) => {
+  for (const input of tx.ins) {
+    const witness = input.witness;
+    if (!witness || witness.length < 2) continue;
+    const tapscript = witness[witness.length - 2];
+    if (!tapscript) continue;
+    const decompiled = bscript.decompile(tapscript);
+    if (!decompiled) continue;
+    const payload = extractOrdinalPayload(decompiled);
+    if (payload && payload.subarray(0, 3).equals(REW_MAGIC)) return payload;
+  }
+  return;
+};
+
+const decodeVaultEntry = (payload: Buffer) => {
+  let offset = 0;
+  const version = payload.readUInt8(offset);
+  offset += 1;
+
+  const triggerLen = decodeVarInt(payload, offset);
+  offset += decodeVarInt.bytes;
+  const triggerTx = payload.slice(offset, offset + triggerLen);
+  offset += triggerLen;
+
+  const panicLen = decodeVarInt(payload, offset);
+  offset += decodeVarInt.bytes;
+  const panicTx = payload.slice(offset, offset + panicLen);
+
+  return { version, triggerTx, panicTx };
+};
+
+const decryptVaultEntry = async ({
+  payload,
+  vaultIndex,
+  masterNode,
+  network
+}: {
+  payload: Buffer;
+  vaultIndex: number;
+  masterNode: BIP32Interface;
+  network: Network;
+}) => {
+  if (!payload.subarray(0, 3).equals(REW_MAGIC))
+    throw new Error('Backup payload missing REW header');
+  const vaultPath = `m${getVaultOriginPath(network)}/${vaultIndex}`;
+  const cipherKey = await getSeedDerivedCipherKey({ vaultPath, masterNode });
+  const cipher = await getManagedChacha(cipherKey);
+  const decrypted = Buffer.from(cipher.decrypt(payload.subarray(3)));
+  return decodeVaultEntry(decrypted);
+};
+
+export const fetchVaultParentsFromBackup = async ({
+  vaultIndex,
+  backupDescriptor,
+  masterNode,
+  network,
+  explorer
+}: {
+  vaultIndex: number;
+  backupDescriptor: string;
+  masterNode: BIP32Interface;
+  network: Network;
+  explorer: Explorer;
+}) => {
+  const historyRetries = 10;
+  const historyDelayMs = 1000;
+  Log(`🔍 Retrieving backup payload from chain for vault #${vaultIndex}...`);
+  const backupOutput = new Output({
+    descriptor: backupDescriptor,
+    index: vaultIndex,
+    network
+  });
+  const backupScript = backupOutput.getScriptPubKey();
+  const scriptHash = getScriptHash(backupScript);
+  let history: Array<{
+    txId: string;
+    blockHeight: number;
+    irreversible: boolean;
+  }> = [];
+  for (let attempt = 1; attempt <= historyRetries; attempt += 1) {
+    history = await explorer.fetchTxHistory({ scriptHash });
+    if (history.length) break;
+    if (attempt < historyRetries) {
+      Log(
+        `⏳ Waiting for backup output history... (${attempt}/${historyRetries})`
+      );
+      await wait(historyDelayMs);
+    }
+  }
+  if (!history.length) throw new Error('No backup history found yet');
+
+  let vaultTxHex;
+  let vaultVout = -1;
+  for (const txData of history) {
+    const txHex = await explorer.fetchTx(txData.txId);
+    const { tx } = transactionFromHex(txHex);
+    const vout = tx.outs.findIndex(out => out.script.equals(backupScript));
+    if (vout >= 0) {
+      vaultTxHex = txHex;
+      vaultVout = vout;
+      break;
+    }
+  }
+  if (!vaultTxHex || vaultVout < 0)
+    throw new Error('Backup funding tx not found for this vault');
+
+  let spendingTx:
+    | { txHex: string; irreversible: boolean; blockHeight: number }
+    | undefined;
+  for (let attempt = 1; attempt <= historyRetries; attempt += 1) {
+    spendingTx = await fetchSpendingTx(vaultTxHex, vaultVout, explorer);
+    if (spendingTx) break;
+    if (attempt < historyRetries) {
+      Log(
+        `⏳ Waiting for backup output spend... (${attempt}/${historyRetries})`
+      );
+      await wait(historyDelayMs);
+    }
+  }
+  if (!spendingTx)
+    throw new Error('Backup output not spent yet; no backup tx found');
+
+  Log(`🧾 Backup output spend located. Fetching payload...`);
+  const spendingTxHex = spendingTx.txHex;
+  const spendingTxObj = Transaction.fromHex(spendingTxHex);
+
+  let payloadSource: 'op_return' | 'inscription' = 'op_return';
+  let payload = extractOpReturnPayload(spendingTxObj);
+  if (!payload) {
+    Log(`🧭 Following inscription commit to reveal tx...`);
+    let revealTx:
+      | { txHex: string; irreversible: boolean; blockHeight: number }
+      | undefined;
+    for (let attempt = 1; attempt <= historyRetries; attempt += 1) {
+      revealTx = await fetchSpendingTx(spendingTxHex, 0, explorer);
+      if (revealTx) break;
+      if (attempt < historyRetries) {
+        Log(
+          `⏳ Waiting for inscription reveal tx... (${attempt}/${historyRetries})`
+        );
+        await wait(historyDelayMs);
+      }
+    }
+    if (!revealTx) throw new Error('Could not locate inscription reveal tx');
+    payload = extractInscriptionPayload(Transaction.fromHex(revealTx.txHex));
+    payloadSource = 'inscription';
+  }
+
+  if (!payload) throw new Error('Backup payload not found in chain data');
+
+  Log(
+    `🧬 Backup payload located (${payloadSource}); decrypting and rebuilding parents...`
+  );
+
+  const { triggerTx, panicTx } = await decryptVaultEntry({
+    payload,
+    vaultIndex,
+    masterNode,
+    network
+  });
+
+  Log(`✅ Reconstructed trigger and panic transactions from backup.`);
+
+  return {
+    triggerTx: Transaction.fromBuffer(triggerTx),
+    panicTx: Transaction.fromBuffer(panicTx)
+  };
+};

--- a/descriptors/rewind2/backupRecovery.ts
+++ b/descriptors/rewind2/backupRecovery.ts
@@ -227,14 +227,14 @@ export const fetchVaultParentsFromBackup = async ({
   if (!spendingTx)
     throw new Error('Backup output not spent yet; no backup tx found');
 
-  Log(`🧾 Backup output spend located. Fetching payload...`);
+  Log(`🔍 Backup output spend located. Fetching payload...`);
   const spendingTxHex = spendingTx.txHex;
   const spendingTxObj = Transaction.fromHex(spendingTxHex);
 
   let payloadSource: 'op_return' | 'inscription' = 'op_return';
   let payload = extractOpReturnPayload(spendingTxObj);
   if (!payload) {
-    Log(`🧭 Following inscription commit to reveal tx...`);
+    Log(`🔍 Following inscription commit to reveal tx...`);
     let revealTx:
       | { txHex: string; irreversible: boolean; blockHeight: number }
       | undefined;
@@ -256,7 +256,7 @@ export const fetchVaultParentsFromBackup = async ({
   if (!payload) throw new Error('Backup payload not found in chain data');
 
   Log(
-    `🧬 Backup payload located (${payloadSource}); decrypting and rebuilding parents...`
+    `🔐 Encrypted backup payload located (${payloadSource}); decrypting and recovering data...`
   );
 
   const { triggerTx, panicTx } = await decryptVaultEntry({

--- a/descriptors/rewind2/index.ts
+++ b/descriptors/rewind2/index.ts
@@ -237,7 +237,6 @@ const pushParentWithCpfp = async (label: 'trigger' | 'panic') => {
     Log(`⚠️ Could not push ${label}: ${cpfp}`);
     return false;
   }
-  if (cpfp.warning) Log(`⚠️ ${cpfp.warning}`);
 
   Log(`📦 Pushing ${label} + CPFP child...`);
   const pkgUrl = `${ESPLORA_API}/txs/package`;

--- a/descriptors/rewind2/index.ts
+++ b/descriptors/rewind2/index.ts
@@ -48,7 +48,6 @@ import {
   wait
 } from './utils';
 
-// TODO: Payload encryption.
 const FEE_RATE = 2.0;
 const VAULT_GAP_LIMIT = 20;
 const FAUCET_FETCH_RETRIES = 10;
@@ -534,7 +533,7 @@ Please retry (max 2 faucet requests per IP/address per minute).`
   );
 
   if (backupType === 'INSCRIPTION') {
-    const inscriptionPsbts = createInscriptionBackup({
+    const inscriptionPsbts = await createInscriptionBackup({
       vaultIndex,
       feeRate: FEE_RATE,
       psbtTrigger,
@@ -559,7 +558,7 @@ Please retry (max 2 faucet requests per IP/address per minute).`
  panic tx id: ${explorerTxLink(psbtPanic.extractTransaction().getId())}
  `);
   } else {
-    const psbtBackup = createOpReturnBackup({
+    const psbtBackup = await createOpReturnBackup({
       psbtTrigger,
       psbtPanic,
       psbtVault,

--- a/descriptors/rewind2/package.json
+++ b/descriptors/rewind2/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/rewind2/vaultSizes.ts
+++ b/descriptors/rewind2/vaultSizes.ts
@@ -116,9 +116,11 @@ const VAULT_ENTRY_BYTES = uniqueSorted(
     )
   )
 );
-//
-//"REW" = 3-byte
-const VAULT_CONTENT_BYTES = VAULT_ENTRY_BYTES.map(bytes => bytes + 3);
+// "REW" = 3-byte, plus XChaCha20-Poly1305 nonce (24) and tag (16).
+const ENCRYPTION_OVERHEAD_BYTES = 24 + 16;
+const VAULT_CONTENT_BYTES = VAULT_ENTRY_BYTES.map(
+  bytes => bytes + 3 + ENCRYPTION_OVERHEAD_BYTES
+);
 const P2WPKH_WITNESS_BYTES = [108, 109, 110, 111];
 
 const OP_RETURN_SCRIPT_BYTES = VAULT_CONTENT_BYTES.map(opReturnScriptBytes);

--- a/descriptors/rewind2/vaultSizes.ts
+++ b/descriptors/rewind2/vaultSizes.ts
@@ -7,8 +7,7 @@ const uniqueSorted = (values: number[]) =>
     .filter((value, index, array) => array.indexOf(value) === index)
     .sort((a, b) => a - b);
 
-export const INSCRIPTION_CONTENT_TYPE =
-  'application/vnd.rewindbitcoin;readme=inscription:123456';
+export const INSCRIPTION_CONTENT_TYPE = 'application/vnd.rewindbitcoin';
 const INSCRIPTION_CONTENT_TYPE_BYTES = Buffer.byteLength(
   INSCRIPTION_CONTENT_TYPE
 );

--- a/descriptors/rewind2/vaults.ts
+++ b/descriptors/rewind2/vaults.ts
@@ -2,6 +2,10 @@ const LOCK_BLOCKS = 2;
 const P2A_SCRIPT = Buffer.from('51024e73', 'hex');
 const VAULT_PURPOSE = 1073;
 const MIN_RELAY_FEE_RATE = 0.1;
+// P2A input weight = base input (36 prevout + 1 scriptLen + 4 sequence) * 4
+// plus segwit marker/flag (2) and witness (1 stack item count + 1 empty push)
+// so weight = 41*4 + 2 + 2 = 166 wu => vsize = ceil(166/4) = 42 vB.
+const P2A_INPUT_WEIGHT = 166;
 
 export type BackupType = 'INSCRIPTION' | 'OP_RETURN_TRUC' | 'OP_RETURN_V2';
 export const BACKUP_TYPES: BackupType[] = [
@@ -54,7 +58,12 @@ import { compilePolicy } from '@bitcoinerlab/miniscript';
 import { InscriptionsFactory } from './inscriptions';
 import { getManagedChacha, getSeedDerivedCipherKey } from './cipher';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
-import { coinselect, dustThreshold, maxFunds } from '@bitcoinerlab/coinselect';
+import {
+  coinselect,
+  dustThreshold,
+  maxFunds,
+  vsize
+} from '@bitcoinerlab/coinselect';
 const { Inscription } = InscriptionsFactory(secp256k1);
 
 const getInscriptionCommitOutputBackupPath = (
@@ -797,13 +806,18 @@ export const createP2ACpfpChild = ({
       targetFee: number;
       outputValue: number;
       reserveValue: number;
-      warning?: string;
     }
   | string => {
   if (!anchorReserveUtxosData.length) return 'NO_ANCHOR_RESERVE_UTXOS';
-  const reserveValue = getUtxosValue(anchorReserveUtxosData);
+  const MAX_TRUC_CHILD_VSIZE = 1000; // TRUC v3 child size limit (vbytes)
 
-  const buildChild = (outputValue: number) => {
+  const buildChild = ({
+    outputValue,
+    selectedUtxosData
+  }: {
+    outputValue: number;
+    selectedUtxosData: UtxosData;
+  }) => {
     const psbt = new Psbt({ network });
     psbt.setVersion(3);
     psbt.addInput({
@@ -811,7 +825,7 @@ export const createP2ACpfpChild = ({
       index: 0,
       witnessUtxo: { script: P2A_SCRIPT, value: 0 }
     });
-    const anchorInputFinalizers = anchorReserveUtxosData.map(utxo =>
+    const anchorInputFinalizers = selectedUtxosData.map(utxo =>
       utxo.output.updatePsbtAsInput({
         psbt,
         txHex: utxo.txHex,
@@ -829,30 +843,71 @@ export const createP2ACpfpChild = ({
     return { psbt, tx, vsize: tx.virtualSize() };
   };
 
-  const provisional = buildChild(reserveValue);
-  const targetFee = Math.ceil((parentVsize + provisional.vsize) * feeRate);
-  const outputValue = reserveValue - targetFee;
+  const estimateChildVsize = (selectedUtxosData: UtxosData) => {
+    const inputs = [
+      {
+        isSegwit: () => true,
+        inputWeight: () => P2A_INPUT_WEIGHT
+      },
+      ...selectedUtxosData.map(utxo => utxo.output)
+    ];
+    return vsize(inputs as unknown as OutputInstance[], [anchorReserveOutput]);
+  };
+
   const dust = dustThreshold(anchorReserveOutput);
-  if (outputValue <= dust)
-    return `ANCHOR_CHANGE_BELOW_DUST: ${Math.max(outputValue, 0)} <= ${dust}`;
-  const warningMessages = [];
-  if (reserveValue < targetFee)
-    warningMessages.push(
-      `Anchor reserve (${reserveValue} sats) is below target fee (${targetFee} sats).`
-    );
-  const finalValue = Math.max(0, outputValue);
-  const finalChild = buildChild(finalValue);
-  const warning = warningMessages.length
-    ? warningMessages.join(' ')
-    : undefined;
+  const sortByValueAsc = (a: UtxosData[number], b: UtxosData[number]) => {
+    const aValue = a.tx.outs[a.vout]?.value ?? 0;
+    const bValue = b.tx.outs[b.vout]?.value ?? 0;
+    return aValue - bValue;
+  };
+  const sortByValueDesc = (a: UtxosData[number], b: UtxosData[number]) => {
+    const aValue = a.tx.outs[a.vout]?.value ?? 0;
+    const bValue = b.tx.outs[b.vout]?.value ?? 0;
+    return bValue - aValue;
+  };
+  const attemptSelection = (sortedUtxosData: UtxosData) => {
+    const selectedUtxosData: UtxosData = [];
+    let targetFee = 0;
+    let outputValue = 0;
+    let childVsize = 0;
+    for (const candidate of sortedUtxosData) {
+      selectedUtxosData.push(candidate);
+      childVsize = estimateChildVsize(selectedUtxosData);
+      if (childVsize > MAX_TRUC_CHILD_VSIZE)
+        return {
+          error: `TRUC_CHILD_TOO_LARGE: ${childVsize} > ${MAX_TRUC_CHILD_VSIZE}`
+        };
+      const reserveValue = getUtxosValue(selectedUtxosData);
+      targetFee = Math.ceil((parentVsize + childVsize) * feeRate);
+      outputValue = reserveValue - targetFee;
+      if (outputValue > dust)
+        return { selectedUtxosData, targetFee, outputValue, childVsize };
+    }
+    return {
+      error: `ANCHOR_CHANGE_BELOW_DUST: ${Math.max(outputValue, 0)} <= ${dust}`
+    };
+  };
+  // First try consolidation by spending smaller reserve UTXOs; if the child
+  // grows past TRUC limits or still leaves dust change, fall back to larger
+  // UTXOs to keep the CPFP child small and reliable.
+  const consolidationSelection = attemptSelection(
+    [...anchorReserveUtxosData].sort(sortByValueAsc)
+  );
+  const finalSelection =
+    'error' in consolidationSelection
+      ? attemptSelection([...anchorReserveUtxosData].sort(sortByValueDesc))
+      : consolidationSelection;
+  if ('error' in finalSelection) return finalSelection.error;
+  const { selectedUtxosData, targetFee, outputValue } = finalSelection;
+  const reserveValue = getUtxosValue(selectedUtxosData);
+  const finalChild = buildChild({ outputValue, selectedUtxosData });
 
   return {
     psbt: finalChild.psbt,
     tx: finalChild.tx,
     childVsize: finalChild.vsize,
     targetFee,
-    outputValue: finalValue,
-    reserveValue,
-    ...(warning ? { warning } : {})
+    outputValue,
+    reserveValue
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@jl.landabaso/btcmessage": "^3.0.0",
         "@ledgerhq/hw-transport-node-hid": "^6.29.14",
         "@ledgerhq/hw-transport-webhid": "^6.30.9",
+        "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^1.3.1",
         "bip39": "^3.1.0",
         "bip65": "^1.0.3",
@@ -24,8 +25,7 @@
         "fs": "^0.0.1-security",
         "ledger-bitcoin": "^0.2.3",
         "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.1.0",
-        "sodium-javascript": "^0.8.0"
+        "randombytes": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^24.10.1",
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
       "cpu": [
         "ppc64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
       "cpu": [
         "arm"
       ],
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
       "cpu": [
         "arm64"
       ],
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
       "cpu": [
         "x64"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
       "cpu": [
         "arm64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
       "cpu": [
         "x64"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
       "cpu": [
         "x64"
       ],
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
       "cpu": [
         "arm"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
       "cpu": [
         "arm64"
       ],
@@ -295,9 +295,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
       "cpu": [
         "ia32"
       ],
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
       "cpu": [
         "loong64"
       ],
@@ -329,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
       "cpu": [
         "mips64el"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
       "cpu": [
         "ppc64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
       "cpu": [
         "riscv64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
       "cpu": [
         "s390x"
       ],
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
       "cpu": [
         "x64"
       ],
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
       "cpu": [
         "arm64"
       ],
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
       "cpu": [
         "x64"
       ],
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
       "cpu": [
         "arm64"
       ],
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
       "cpu": [
         "x64"
       ],
@@ -482,9 +482,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
       "cpu": [
         "arm64"
       ],
@@ -499,9 +499,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
       "cpu": [
         "x64"
       ],
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
       "cpu": [
         "arm64"
       ],
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
       "cpu": [
         "ia32"
       ],
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
       "cpu": [
         "x64"
       ],
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -679,7 +679,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -837,88 +837,94 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/@jl.landabaso/btcmessage/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
     "node_modules/@ledgerhq/devices": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.7.0.tgz",
-      "integrity": "sha512-3pSOULPUhClk2oOxa6UnoyXW8+05FK7r6cpq2WiTey4kyIUjmIraO7AX9lhz9IU73dGVtBMdU+NCPPO2RYJaTQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.10.0.tgz",
+      "integrity": "sha512-ytT66KI8MizFX6dGJKthOzPDw5uNRmmg+RaMta62jbFePKYqfXtYTp6Wc0ErTXaL8nFS3IujHENwKthPmsj6jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.27.0",
-        "@ledgerhq/logs": "^6.13.0",
-        "rxjs": "^7.8.1",
-        "semver": "^7.3.5"
+        "@ledgerhq/errors": "^6.29.0",
+        "@ledgerhq/logs": "^6.14.0",
+        "rxjs": "7.8.2",
+        "semver": "7.7.3"
       }
     },
     "node_modules/@ledgerhq/errors": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.27.0.tgz",
-      "integrity": "sha512-EE2hATONHdNP3YWFe3rZwwpSEzI5oN+q/xTjOulnjHZo84TLjungegEJ54A/Pzld0woulkkeVA27FbW5SAO1aA==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.29.0.tgz",
+      "integrity": "sha512-mmDsGN662zd0XGKyjzSKkg+5o1/l9pvV1HkVHtbzaydvHAtRypghmVoWMY9XAQDLXiUBXGIsLal84NgmGeuKWA==",
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.31.13",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.13.tgz",
-      "integrity": "sha512-MrJRDk74wY980ofiFPRpTHQBbRw1wDuKbdag1zqlO1xtJglymwwY03K2kvBNvkm1RTSCPUp/nAoNG+WThZuuew==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.32.0.tgz",
+      "integrity": "sha512-bf2nxzDQ21DV/bsmExfWI0tatoVeoqhu/ePWalD/nPgPnTn/ZIDq7VBU+TY5p0JZaE87NQwmRUAjm6C1Exe61A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.7.0",
-        "@ledgerhq/errors": "^6.27.0",
-        "@ledgerhq/logs": "^6.13.0",
+        "@ledgerhq/devices": "8.10.0",
+        "@ledgerhq/errors": "^6.29.0",
+        "@ledgerhq/logs": "^6.14.0",
         "events": "^3.3.0"
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid": {
-      "version": "6.29.14",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.29.14.tgz",
-      "integrity": "sha512-SqawAnYecZz1tt2VHbhyQMhwadaKhsMjhv9gHu9MmAevLFSVCfgs+6qWmuT+kuxhD1zGneW5TxlW+4B+HcVtWg==",
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.30.0.tgz",
+      "integrity": "sha512-HYaBEnb/LY/YFKVQz+DMmUKIZRUIRHvY94JhBIulXVXlPB3I0MmZBtccVVspz+RzCt1KPe61NMJSc1ebeWcOyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.7.0",
-        "@ledgerhq/errors": "^6.27.0",
-        "@ledgerhq/hw-transport": "6.31.13",
-        "@ledgerhq/hw-transport-node-hid-noevents": "^6.30.14",
-        "@ledgerhq/logs": "^6.13.0",
+        "@ledgerhq/devices": "8.10.0",
+        "@ledgerhq/errors": "^6.29.0",
+        "@ledgerhq/hw-transport": "6.32.0",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^6.31.0",
+        "@ledgerhq/logs": "^6.14.0",
         "lodash": "^4.17.21",
         "node-hid": "2.1.2",
         "usb": "2.9.0"
       }
     },
     "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "6.30.14",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.30.14.tgz",
-      "integrity": "sha512-QG5wd6kjJYYXSmGRoZkDAehX1iN9WdjgHYNW4QwWcw9G6QnAgAYLE6v1u4ZZVVLZ6DrmHKJVOzwm9njYJMit2w==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.31.0.tgz",
+      "integrity": "sha512-81VnmEg/+sHtORYvwhxDibKaXeRIQiKeHj6piW6ii8WR4PoB9gXvJkEohLU5mfirpjAMbp7Br5qZ4ximyJV3nA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.7.0",
-        "@ledgerhq/errors": "^6.27.0",
-        "@ledgerhq/hw-transport": "6.31.13",
-        "@ledgerhq/logs": "^6.13.0",
+        "@ledgerhq/devices": "8.10.0",
+        "@ledgerhq/errors": "^6.29.0",
+        "@ledgerhq/hw-transport": "6.32.0",
+        "@ledgerhq/logs": "^6.14.0",
         "node-hid": "2.1.2"
       }
     },
     "node_modules/@ledgerhq/hw-transport-webhid": {
-      "version": "6.30.9",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.30.9.tgz",
-      "integrity": "sha512-5if/V1NyOr4JuEX+NB/bxaE92TptpgX+r1mGmzDHG6Gs9/fX/HhKe1GVwwU5C7LvTFrdTgMzEs2aIkpoMM60Ag==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.31.0.tgz",
+      "integrity": "sha512-XtCFOJ1ooaqCefB6WDfV/ie+GaO/7xQgezwRpyLroMBYboSpnEd3Diu3BAoptXKTNklwZEiUVRLVXlltTBzNvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.7.0",
-        "@ledgerhq/errors": "^6.27.0",
-        "@ledgerhq/hw-transport": "6.31.13",
-        "@ledgerhq/logs": "^6.13.0"
+        "@ledgerhq/devices": "8.10.0",
+        "@ledgerhq/errors": "^6.29.0",
+        "@ledgerhq/hw-transport": "6.32.0",
+        "@ledgerhq/logs": "^6.14.0"
       }
     },
     "node_modules/@ledgerhq/logs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.13.0.tgz",
-      "integrity": "sha512-4+qRW2Pc8V+btL0QEmdB2X+uyx0kOWMWE1/LWsq5sZy3Q5tpi4eItJS6mB0XL3wGW59RQ+8bchNQQ1OW/va8Og==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.14.0.tgz",
+      "integrity": "sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
@@ -945,44 +951,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1030,9 +998,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1046,21 +1014,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.4.tgz",
-      "integrity": "sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.1.tgz",
+      "integrity": "sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.46.4",
-        "@typescript-eslint/type-utils": "8.46.4",
-        "@typescript-eslint/utils": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/type-utils": "8.53.1",
+        "@typescript-eslint/utils": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1070,23 +1037,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.46.4",
+        "@typescript-eslint/parser": "^8.53.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.4.tgz",
-      "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.1.tgz",
+      "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.46.4",
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/typescript-estree": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1101,15 +1068,15 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.4.tgz",
-      "integrity": "sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
+      "integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.4",
-        "@typescript-eslint/types": "^8.46.4",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.53.1",
+        "@typescript-eslint/types": "^8.53.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1123,14 +1090,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz",
-      "integrity": "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
+      "integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4"
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1141,9 +1108,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz",
-      "integrity": "sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
+      "integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1158,17 +1125,17 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.4.tgz",
-      "integrity": "sha512-V4QC8h3fdT5Wro6vANk6eojqfbv5bpwHuMsBcJUJkqs2z5XnYhJzyz9Y02eUmF9u3PgXEUiOt4w4KHR3P+z0PQ==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.1.tgz",
+      "integrity": "sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/typescript-estree": "8.46.4",
-        "@typescript-eslint/utils": "8.46.4",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1",
+        "@typescript-eslint/utils": "8.53.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1183,9 +1150,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.4.tgz",
-      "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
+      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1197,22 +1164,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz",
-      "integrity": "sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
+      "integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.4",
-        "@typescript-eslint/tsconfig-utils": "8.46.4",
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/visitor-keys": "8.46.4",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.53.1",
+        "@typescript-eslint/tsconfig-utils": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/visitor-keys": "8.53.1",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1226,16 +1192,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.4.tgz",
-      "integrity": "sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.1.tgz",
+      "integrity": "sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.4",
-        "@typescript-eslint/types": "8.46.4",
-        "@typescript-eslint/typescript-estree": "8.46.4"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.53.1",
+        "@typescript-eslint/types": "8.53.1",
+        "@typescript-eslint/typescript-estree": "8.53.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1250,13 +1216,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
-      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
+      "version": "8.53.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
+      "integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/types": "8.53.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1363,20 +1329,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1411,9 +1363,9 @@
       "license": "MIT"
     },
     "node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "license": "MIT"
     },
     "node_modules/bindings": {
@@ -1505,6 +1457,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/bitcoinjs-lib/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1530,26 +1488,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/blake2b": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
-      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
-      "license": "ISC",
-      "dependencies": {
-        "blake2b-wasm": "^2.4.0",
-        "nanoassert": "^2.0.0"
-      }
-    },
-    "node_modules/blake2b-wasm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
-      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "nanoassert": "^2.0.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1558,19 +1496,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/bs58": {
@@ -1672,15 +1597,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/chacha20-universal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz",
-      "integrity": "sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==",
-      "license": "ISC",
-      "dependencies": {
-        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/chalk": {
@@ -1995,9 +1911,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2008,32 +1924,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2051,9 +1967,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2064,7 +1980,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2128,14 +2044,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.7"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -2289,9 +2205,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2390,36 +2306,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2436,14 +2322,22 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2465,19 +2359,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2667,13 +2548,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2850,6 +2724,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2860,21 +2735,12 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -2965,6 +2831,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
       "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
+      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^1.0.2",
@@ -3104,30 +2971,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -3178,12 +3021,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nanoassert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
-      "license": "ISC"
-    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -3204,9 +3041,9 @@
       "license": "ISC"
     },
     "node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -3349,13 +3186,13 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -3408,9 +3245,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3424,9 +3261,9 @@
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3471,27 +3308,6 @@
       "dependencies": {
         "bitcoin-ops": "^1.3.0"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -3568,17 +3384,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ripemd160": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
@@ -3590,30 +3395,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -3694,46 +3475,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sha256-universal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
-      "integrity": "sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==",
-      "license": "ISC",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "sha256-wasm": "^2.2.1"
-      }
-    },
-    "node_modules/sha256-wasm": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
-      "integrity": "sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==",
-      "license": "ISC",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "nanoassert": "^2.0.0"
-      }
-    },
-    "node_modules/sha512-universal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
-      "integrity": "sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==",
-      "license": "ISC",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "sha512-wasm": "^2.3.1"
-      }
-    },
-    "node_modules/sha512-wasm": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz",
-      "integrity": "sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==",
-      "license": "ISC",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "nanoassert": "^2.0.0"
-      }
-    },
     "node_modules/shallow-equal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
@@ -3810,30 +3551,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/siphash24": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
-      "integrity": "sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoassert": "^2.0.0"
-      }
-    },
-    "node_modules/sodium-javascript": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
-      "integrity": "sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==",
-      "license": "MIT",
-      "dependencies": {
-        "blake2b": "^2.1.1",
-        "chacha20-universal": "^1.0.4",
-        "nanoassert": "^2.0.0",
-        "sha256-universal": "^1.1.0",
-        "sha512-universal": "^1.1.0",
-        "siphash24": "^1.0.1",
-        "xsalsa20": "^1.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3878,9 +3595,9 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3948,6 +3665,23 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -3968,23 +3702,10 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4001,13 +3722,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.20.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.25.0",
+        "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
       },
       "bin": {
@@ -4158,9 +3879,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -4232,12 +3953,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/xsalsa20": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
-      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==",
-      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@jl.landabaso/btcmessage": "^3.0.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
+    "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^1.3.1",
     "bip39": "^3.1.0",
     "bip65": "^1.0.3",
@@ -32,8 +33,7 @@
     "fs": "^0.0.1-security",
     "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0",
-    "sodium-javascript": "^0.8.0"
+    "randombytes": "^2.1.0"
   },
   "comment": [
     "Note to devs:",


### PR DESCRIPTION
- Encrypt Rewind2 backup payloads with XChaCha20-Poly1305 using seed‑derived keys and update size calculations accordingly.
- Add on‑chain backup recovery (OP_RETURN/inscription) to reconstruct trigger/panic parents with chain lookup + decryption.
- Chunk inscription payloads to respect 520‑byte pushes and reassemble on decode.
- Refine CPFP child sizing/selection to stay under TRUC limits and avoid multiple signing passes.
- Update Rewind2 docs and logging to reflect backup policies and encryption details.

Notes
- Removes sodium‑javascript in favor of @noble/ciphers.
- INSCRIPTION content type simplified to application/vnd.rewindbitcoin.