### PR TITLE
Migrate playground to descriptors v3/bjs7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ npm run descriptors/legacy2segwit
 
 This will execute the code in `./descriptors/legacy2segwit/index.ts` and output the results.
 
+### Implementation notes
+
+- The playground code follows the `bitcoinjs-lib` v7 stack, so transaction and PSBT values are handled as `bigint`.
+- Miniscript policy compilation is done via `@bitcoinerlab/miniscript-policies`.
+- When deriving BIP44/BIP86 coin type from a `Network`, avoid object-reference checks and use field-based mainnet detection.
+
 ## Available Playgrounds
 
 Below is the full list of playgrounds included in this repository, with links to their corresponding guides on the BitcoinerLab site.

--- a/descriptors/inscriptions/package.json
+++ b/descriptors/inscriptions/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/ledger/codesandboxFixes.ts
+++ b/descriptors/ledger/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/ledger/package.json
+++ b/descriptors/ledger/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/legacy2segwit/codesandboxFixes.ts
+++ b/descriptors/legacy2segwit/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/legacy2segwit/index.ts
+++ b/descriptors/legacy2segwit/index.ts
@@ -6,12 +6,13 @@ import * as secp256k1 from '@bitcoinerlab/secp256k1';
 import * as descriptors from '@bitcoinerlab/descriptors';
 import { mnemonicToSeedSync } from 'bip39';
 import { Psbt, networks } from 'bitcoinjs-lib';
+import { toHex } from 'uint8array-tools';
 const { pkhBIP32, wpkhBIP32 } = descriptors.scriptExpressions;
 const { Output, BIP32 } = descriptors.DescriptorsFactory(secp256k1);
 const network = networks.testnet;
 const EXPLORER = 'https://blockstream.info/testnet';
 const ESPLORA_API = 'https://blockstream.info/testnet/api';
-const FEE = 500;
+const FEE = 500n;
 
 //Let's create our software wallet with this mnemonic:
 const MNEMONIC =
@@ -38,10 +39,9 @@ console.log(`We start with:`, { address: legacyOutput.getAddress(), TXID });
   };
   const txOuts = txJson.vout;
   const vout = txOuts.findIndex(
-    txOut =>
-      txOut.scriptpubkey === legacyOutput.getScriptPubKey().toString('hex')
+    txOut => txOut.scriptpubkey === toHex(legacyOutput.getScriptPubKey())
   );
-  const initialValue = txOuts[vout]!.value; //This must be: 1679037
+  const initialValue = BigInt(txOuts[vout]!.value); //This must be: 1679037
   console.log('This is the utxo to spend :', { txHex, vout, initialValue });
 
   //Define the Segwit descriptor where we will move the funds:

--- a/descriptors/legacy2segwit/package.json
+++ b/descriptors/legacy2segwit/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/luna/codesandboxFixes.ts
+++ b/descriptors/luna/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/luna/index.ts
+++ b/descriptors/luna/index.ts
@@ -10,12 +10,15 @@
 import './codesandboxFixes';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
 import * as descriptors from '@bitcoinerlab/descriptors';
-import { compilePolicy } from '@bitcoinerlab/miniscript';
+import {
+  compilePolicy,
+  ready as miniscriptPoliciesReady
+} from '@bitcoinerlab/miniscript-policies';
 import { networks, Psbt } from 'bitcoinjs-lib';
 import { mnemonicToSeedSync } from 'bip39';
-const { Descriptor, BIP32 } = descriptors.DescriptorsFactory(secp256k1);
+const { Output, BIP32 } = descriptors.DescriptorsFactory(secp256k1);
 
-const FEE = 1000; //This should be enough
+const FEE = 1000n; //This should be enough
 const MY_ADDRESS = '3FYsjXPy81f96odShrKQoAiLFVmt6Tjf4g'; //Put here your address
 const network = networks.bitcoin;
 const MNEMONIC =
@@ -23,42 +26,50 @@ const MNEMONIC =
 const masterNode = BIP32.fromSeed(mnemonicToSeedSync(MNEMONIC), network);
 const POLICY = `or(99@pk(panick),1@and(pk(unvault),older(10)))`;
 
-const { miniscript } = compilePolicy(POLICY);
-const finalMiniscript = miniscript
-  .replace(
-    'unvault',
-    descriptors.keyExpressionBIP32({
-      masterNode: masterNode,
-      originPath: `/48'/0'/1'/2'`,
-      keyPath: `/0/0`
-    })
-  )
-  .replace(
-    'panick',
-    descriptors.keyExpressionBIP32({
-      masterNode: masterNode,
-      originPath: `/48'/0'/0'/2'`,
-      keyPath: `/0/0`
-    })
+const run = async () => {
+  await miniscriptPoliciesReady;
+  const { miniscript } = compilePolicy(POLICY);
+  const finalMiniscript = miniscript
+    .replace(
+      'unvault',
+      descriptors.keyExpressionBIP32({
+        masterNode: masterNode,
+        originPath: `/48'/0'/1'/2'`,
+        keyPath: `/0/0`
+      })
+    )
+    .replace(
+      'panick',
+      descriptors.keyExpressionBIP32({
+        masterNode: masterNode,
+        originPath: `/48'/0'/0'/2'`,
+        keyPath: `/0/0`
+      })
+    );
+  const output = new Output({
+    descriptor: `wsh(${finalMiniscript})`,
+    signersPubKeys: [masterNode.derivePath(`m/48'/0'/0'/2'/0/0`).publicKey],
+    network
+  });
+  console.log(`Let's create a Psbt that spends from: ${output.getAddress()}`);
+  const psbt = new Psbt({ network });
+  const inputFinalizer = output.updatePsbtAsInput({
+    psbt,
+    txHex:
+      '02000000000101c320e40e2495375461eaa9d19e522fe17bb2d5d605a3c5ee3b308a02c5001d780000000000feffffff0273111f02000000001600145193feffae91b55aee55790f8746d0cdd3e543d2a086010000000000220020a95633d613fd8e89c255e3e34e4c0d1ce401ac07026acefc3652816f60951e6202473044022029561fafd929cc71558e27e9c0bd4bf4bf0aecf2a43838f15ff5625b491fdb3e0220073e46f7dc7c49633992d6fc166c1c328fff6e778b7dd65721e3718d02bc2fe201210396c2490a9779545052c7a03b6e88823aa0f6122224c8cce2a211bcf293a6ac2800000000',
+    vout: 1
+  });
+  psbt.addOutput({
+    address: MY_ADDRESS,
+    value: 100000n - FEE
+  });
+  descriptors.signers.signBIP32({ psbt, masterNode });
+  inputFinalizer({ psbt });
+  const spendTx = psbt.extractTransaction();
+  console.log(
+    'Paste text to: https://blockstream.info/tx/push',
+    spendTx.toHex()
   );
-const descriptor = new Descriptor({
-  expression: `wsh(${finalMiniscript})`,
-  signersPubKeys: [masterNode.derivePath(`m/48'/0'/0'/2'/0/0`).publicKey],
-  network
-});
-console.log(`Let's create a Psbt that spends from: ${descriptor.getAddress()}`);
-const psbt = new Psbt({ network });
-descriptor.updatePsbt({
-  psbt,
-  txHex:
-    '02000000000101c320e40e2495375461eaa9d19e522fe17bb2d5d605a3c5ee3b308a02c5001d780000000000feffffff0273111f02000000001600145193feffae91b55aee55790f8746d0cdd3e543d2a086010000000000220020a95633d613fd8e89c255e3e34e4c0d1ce401ac07026acefc3652816f60951e6202473044022029561fafd929cc71558e27e9c0bd4bf4bf0aecf2a43838f15ff5625b491fdb3e0220073e46f7dc7c49633992d6fc166c1c328fff6e778b7dd65721e3718d02bc2fe201210396c2490a9779545052c7a03b6e88823aa0f6122224c8cce2a211bcf293a6ac2800000000',
-  vout: 1
-});
-psbt.addOutput({
-  address: MY_ADDRESS,
-  value: 100000 - FEE
-});
-descriptors.signers.signBIP32({ psbt, masterNode });
-descriptor.finalizePsbtInput({ index: 0, psbt });
-const spendTx = psbt.extractTransaction();
-console.log('Paste text to: https://blockstream.info/tx/push', spendTx.toHex());
+};
+
+void run();

--- a/descriptors/luna/package.json
+++ b/descriptors/luna/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/miniscript/codesandboxFixes.ts
+++ b/descriptors/miniscript/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/miniscript/package.json
+++ b/descriptors/miniscript/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/multisig-fallback-timelock/codesandboxFixes.ts
+++ b/descriptors/multisig-fallback-timelock/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/multisig-fallback-timelock/package.json
+++ b/descriptors/multisig-fallback-timelock/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/p2a/codesandboxFixes.ts
+++ b/descriptors/p2a/codesandboxFixes.ts
@@ -26,14 +26,14 @@
  * The file is shared across npm projects and hardlinked to each,
  * maintained in the root folder:
 
- rm descriptors/ledger/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts descriptors/luna/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
-
  rm descriptors/ledger/codesandboxFixes.ts
  rm descriptors/legacy2segwit/codesandboxFixes.ts
  rm descriptors/luna/codesandboxFixes.ts
  rm descriptors/miniscript/codesandboxFixes.ts
  rm descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  rm descriptors/p2a/codesandboxFixes.ts
+ rm descriptors/rewind2/codesandboxFixes.ts
+ rm descriptors/inscriptions/codesandboxFixes.ts
 
  ln descriptors/codesandboxFixes.ts descriptors/ledger/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/legacy2segwit/codesandboxFixes.ts
@@ -41,6 +41,8 @@
  ln descriptors/codesandboxFixes.ts descriptors/miniscript/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/multisig-fallback-timelock/codesandboxFixes.ts
  ln descriptors/codesandboxFixes.ts descriptors/p2a/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/rewind2/codesandboxFixes.ts
+ ln descriptors/codesandboxFixes.ts descriptors/inscriptions/codesandboxFixes.ts
 
  */
 

--- a/descriptors/p2a/package.json
+++ b/descriptors/p2a/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/rewind2/backupRecovery.ts
+++ b/descriptors/rewind2/backupRecovery.ts
@@ -7,6 +7,7 @@ import {
   type Network
 } from 'bitcoinjs-lib';
 import { decode as decodeVarInt } from 'varuint-bitcoin';
+import { compare, concat, fromUtf8, toHex } from 'uint8array-tools';
 import type { Explorer } from '@bitcoinerlab/explorer';
 import { getManagedChacha, getSeedDerivedCipherKey } from './cipher';
 import { getVaultOriginPath } from './vaults';
@@ -16,8 +17,8 @@ import { DescriptorsFactory } from '@bitcoinerlab/descriptors';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
 const { Output } = DescriptorsFactory(secp256k1);
 
-const REW_MAGIC = Buffer.from('REW');
-const ORD_MARKER = Buffer.from('ord');
+const REW_MAGIC = fromUtf8('REW');
+const ORD_MARKER = fromUtf8('ord');
 const spendingTxCache = new Map<
   string,
   { txHex: string; irreversible: boolean; blockHeight: number }
@@ -28,8 +29,14 @@ const transactionFromHex = (txHex: string) => {
   return { tx, txId: tx.getId() };
 };
 
-const getScriptHash = (script: Buffer) =>
-  Buffer.from(sha256(script)).reverse().toString('hex');
+const reverseBytes = (bytes: Uint8Array): Uint8Array => {
+  const copy = Uint8Array.from(bytes);
+  copy.reverse();
+  return copy;
+};
+
+const getScriptHash = (script: Uint8Array) =>
+  toHex(reverseBytes(sha256(script)));
 
 const fetchSpendingTx = async (
   txHex: string,
@@ -45,16 +52,14 @@ const fetchSpendingTx = async (
   const { tx, txId } = transactionFromHex(txHex);
   const output = tx.outs[vout];
   if (!output) throw new Error('Invalid output when locating spending tx');
-  const scriptHash = Buffer.from(sha256(output.script))
-    .reverse()
-    .toString('hex');
+  const scriptHash = toHex(reverseBytes(sha256(output.script)));
 
   const history = await explorer.fetchTxHistory({ scriptHash });
   for (const txData of history) {
     const historyTxHex = await explorer.fetchTx(txData.txId);
     const { tx: historyTx } = transactionFromHex(historyTxHex);
     const found = historyTx.ins.some(input => {
-      const inputPrevtxId = Buffer.from(input.hash).reverse().toString('hex');
+      const inputPrevtxId = toHex(reverseBytes(input.hash));
       return inputPrevtxId === txId && input.index === vout;
     });
     if (found) {
@@ -76,7 +81,8 @@ const extractOpReturnPayload = (tx: Transaction) => {
     try {
       const embed = payments.embed({ output: output.script });
       const payload = embed.data?.[0];
-      if (payload && payload.subarray(0, 3).equals(REW_MAGIC)) return payload;
+      if (payload && compare(payload.subarray(0, 3), REW_MAGIC) === 0)
+        return payload;
     } catch {
       continue;
     }
@@ -84,20 +90,20 @@ const extractOpReturnPayload = (tx: Transaction) => {
   return;
 };
 
-const extractOrdinalPayload = (chunks: Array<number | Buffer>) => {
+const extractOrdinalPayload = (chunks: Array<number | Uint8Array>) => {
   for (let i = 0; i < chunks.length - 1; i += 1) {
     const item = chunks[i];
-    if (Buffer.isBuffer(item) && item.equals(ORD_MARKER)) {
+    if (item instanceof Uint8Array && compare(item, ORD_MARKER) === 0) {
       for (let j = i + 1; j < chunks.length - 1; j += 1) {
         if (chunks[j] === opcodes['OP_0']) {
-          const payloadChunks: Buffer[] = [];
+          const payloadChunks: Uint8Array[] = [];
           for (let k = j + 1; k < chunks.length; k += 1) {
             const chunk = chunks[k];
             if (!chunk) break;
             if (typeof chunk === 'number') break;
             payloadChunks.push(chunk);
           }
-          if (payloadChunks.length) return Buffer.concat(payloadChunks);
+          if (payloadChunks.length) return concat(payloadChunks);
         }
       }
     }
@@ -114,24 +120,30 @@ const extractInscriptionPayload = (tx: Transaction) => {
     const decompiled = bscript.decompile(tapscript);
     if (!decompiled) continue;
     const payload = extractOrdinalPayload(decompiled);
-    if (payload && payload.subarray(0, 3).equals(REW_MAGIC)) return payload;
+    if (payload && compare(payload.subarray(0, 3), REW_MAGIC) === 0)
+      return payload;
   }
   return;
 };
 
-const decodeVaultEntry = (payload: Buffer) => {
+const decodeVaultEntry = (payload: Uint8Array) => {
   let offset = 0;
-  const version = payload.readUInt8(offset);
+  const version = payload[offset];
+  if (version === undefined) throw new Error('Missing backup entry version');
   offset += 1;
 
-  const triggerLen = decodeVarInt(payload, offset);
-  offset += decodeVarInt.bytes;
-  const triggerTx = payload.slice(offset, offset + triggerLen);
+  const triggerLenInfo = decodeVarInt(payload, offset);
+  const triggerLen = triggerLenInfo.numberValue;
+  if (triggerLen === null) throw new Error('Invalid trigger tx varint length');
+  offset += triggerLenInfo.bytes;
+  const triggerTx = payload.subarray(offset, offset + triggerLen);
   offset += triggerLen;
 
-  const panicLen = decodeVarInt(payload, offset);
-  offset += decodeVarInt.bytes;
-  const panicTx = payload.slice(offset, offset + panicLen);
+  const panicLenInfo = decodeVarInt(payload, offset);
+  const panicLen = panicLenInfo.numberValue;
+  if (panicLen === null) throw new Error('Invalid panic tx varint length');
+  offset += panicLenInfo.bytes;
+  const panicTx = payload.subarray(offset, offset + panicLen);
 
   return { version, triggerTx, panicTx };
 };
@@ -142,17 +154,17 @@ const decryptVaultEntry = async ({
   masterNode,
   network
 }: {
-  payload: Buffer;
+  payload: Uint8Array;
   vaultIndex: number;
   masterNode: BIP32Interface;
   network: Network;
 }) => {
-  if (!payload.subarray(0, 3).equals(REW_MAGIC))
+  if (compare(payload.subarray(0, 3), REW_MAGIC) !== 0)
     throw new Error('Backup payload missing REW header');
   const vaultPath = `m${getVaultOriginPath(network)}/${vaultIndex}`;
   const cipherKey = await getSeedDerivedCipherKey({ vaultPath, masterNode });
   const cipher = await getManagedChacha(cipherKey);
-  const decrypted = Buffer.from(cipher.decrypt(payload.subarray(3)));
+  const decrypted = cipher.decrypt(payload.subarray(3));
   return decodeVaultEntry(decrypted);
 };
 
@@ -201,7 +213,9 @@ export const fetchVaultParentsFromBackup = async ({
   for (const txData of history) {
     const txHex = await explorer.fetchTx(txData.txId);
     const { tx } = transactionFromHex(txHex);
-    const vout = tx.outs.findIndex(out => out.script.equals(backupScript));
+    const vout = tx.outs.findIndex(
+      out => compare(out.script, backupScript) === 0
+    );
     if (vout >= 0) {
       vaultTxHex = txHex;
       vaultVout = vout;

--- a/descriptors/rewind2/cipher.ts
+++ b/descriptors/rewind2/cipher.ts
@@ -3,7 +3,7 @@ const SIGNING_MESSAGE = 'Satoshi Nakamoto'; //Can be any, but don't change it
 
 import type { BIP32Interface } from 'bip32';
 import { sha256 } from '@noble/hashes/sha2';
-import { MessageFactory } from '@jl.landabaso/btcmessage';
+import { MessageFactory } from '@bitcoinerlab/btcmessage';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
 import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
 import {
@@ -31,10 +31,8 @@ export const getManagedChacha = async (key: Uint8Array) => {
 /*
  *  const PURPOSE = 1073;
  *  const VAULT_PATH = `m/${PURPOSE}'/<network>'/0'/<index>`;
- *  const vaultPath = VAULT_PATH.replace(
- *      '<network>',
- *      network === networks.bitcoin ? '0' : '1'
- *    ).replace('<index>', index.toString());
+ *  const vaultPath = VAULT_PATH.replace('<network>', coinTypeFromNetwork(network).toString())
+ *    .replace('<index>', index.toString());
  */
 
 export const getSeedDerivedCipherKey = async ({

--- a/descriptors/rewind2/networkUtils.ts
+++ b/descriptors/rewind2/networkUtils.ts
@@ -1,0 +1,17 @@
+import { networks } from 'bitcoinjs-lib';
+import type { Network } from 'bitcoinjs-lib';
+
+export function isBitcoinMainnet(network: Network): boolean {
+  return (
+    network.bech32 === networks.bitcoin.bech32 &&
+    network.bip32.public === networks.bitcoin.bip32.public &&
+    network.bip32.private === networks.bitcoin.bip32.private &&
+    network.pubKeyHash === networks.bitcoin.pubKeyHash &&
+    network.scriptHash === networks.bitcoin.scriptHash &&
+    network.wif === networks.bitcoin.wif
+  );
+}
+
+export function coinTypeFromNetwork(network: Network): 0 | 1 {
+  return isBitcoinMainnet(network) ? 0 : 1;
+}

--- a/descriptors/rewind2/package.json
+++ b/descriptors/rewind2/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",

--- a/descriptors/rewind2/vaultSizes.ts
+++ b/descriptors/rewind2/vaultSizes.ts
@@ -2,16 +2,18 @@
 import { encodingLength as pushdataEncodingLength } from 'pushdata-bitcoin';
 import { encodingLength } from 'varuint-bitcoin';
 
+const textEncoder = new TextEncoder();
+
 const uniqueSorted = (values: number[]) =>
   values
     .filter((value, index, array) => array.indexOf(value) === index)
     .sort((a, b) => a - b);
 
 export const INSCRIPTION_CONTENT_TYPE = 'application/vnd.rewindbitcoin';
-const INSCRIPTION_CONTENT_TYPE_BYTES = Buffer.byteLength(
+const INSCRIPTION_CONTENT_TYPE_BYTES = textEncoder.encode(
   INSCRIPTION_CONTENT_TYPE
-);
-const INSCRIPTION_PROTOCOL_ID_BYTES = Buffer.byteLength('ord');
+).length;
+const INSCRIPTION_PROTOCOL_ID_BYTES = textEncoder.encode('ord').length;
 
 // https://github.com/bitcoin/bitcoin/blob/22bde74d1d8f861323eabb8dc60401bbf1226544/src/policy/policy.h#L36
 const MIN_STANDARD_TX_NONWITNESS_SIZE = 65;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,34 @@
 {
   "name": "playground",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playground",
-      "version": "2.5.0",
+      "version": "3.0.0",
       "dependencies": {
-        "@bitcoinerlab/coinselect": "^1.3.4",
-        "@bitcoinerlab/descriptors": "^2.3.6",
-        "@bitcoinerlab/discovery": "^1.5.3",
-        "@bitcoinerlab/explorer": "^0.4.2",
-        "@bitcoinerlab/miniscript": "^1.4.3",
+        "@bitcoinerlab/btcmessage": "^4.0.1",
+        "@bitcoinerlab/coinselect": "^2.0.0",
+        "@bitcoinerlab/descriptors": "^3.0.2",
+        "@bitcoinerlab/discovery": "^2.0.0",
+        "@bitcoinerlab/explorer": "^1.0.0",
+        "@bitcoinerlab/miniscript": "^2.0.0",
+        "@bitcoinerlab/miniscript-policies": "^1.1.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
-        "@jl.landabaso/btcmessage": "^3.0.0",
         "@ledgerhq/hw-transport-node-hid": "^6.29.14",
         "@ledgerhq/hw-transport-webhid": "^6.30.9",
+        "@ledgerhq/ledger-bitcoin": "^0.3.0",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^1.3.1",
         "bip39": "^3.1.0",
         "bip65": "^1.0.3",
         "create-hash": "^1.2.0",
         "fs": "^0.0.1-security",
-        "ledger-bitcoin": "^0.2.3",
         "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.1.0"
+        "randombytes": "^2.1.0",
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^24.10.1",
@@ -38,53 +41,101 @@
         "typescript": "^5.9.3"
       }
     },
-    "node_modules/@bitcoinerlab/coinselect": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/coinselect/-/coinselect-1.3.4.tgz",
-      "integrity": "sha512-tDqEQp2SOzG16sYwgxW3r+IGqA5j0TSSgZbuURqp1JcPDjRhjnKJ1G6FIlelb271hI7FsUIgtUzygKXKK9beoA==",
+    "node_modules/@bitcoinerlab/btcmessage": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/btcmessage/-/btcmessage-4.0.1.tgz",
+      "integrity": "sha512-wBeKZERl2NRQm6t9WMy7IhVXse9ChxxuBhtlWBeqFo91eNBLKrOUYL7+Tphq65rKD/SsIj1MkemGm6gOpqnx8A==",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.3.4"
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@bitcoinerlab/btcmessage/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@bitcoinerlab/btcmessage/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/@bitcoinerlab/btcmessage/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@bitcoinerlab/btcmessage/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/@bitcoinerlab/coinselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/coinselect/-/coinselect-2.0.0.tgz",
+      "integrity": "sha512-RL0syzp90FDT7MrFGWxfUitDsJ2BwPNhfEJ8lk509S+dA1v63fVnN4XAwRcKls7uulnR9sblH93Qfo2cBTn4qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^3.0.2"
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.6.tgz",
-      "integrity": "sha512-joBjyYMGlzdOwieZlQ37oONy27/cu+EvotVmKmoKRsNIEy40lAiQC6ImaQsLk08PQjlh1SqEBXhSN5CuxK+T1A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-3.0.2.tgz",
+      "integrity": "sha512-qU8BqHF4t8/PV3jRWfxH+wobkK0cirsDCMmhyFPU0ttwVEDEsWB9IsbmYR7K3nZihFWbPx2E4zz0iHLD1Kf8aQ==",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/miniscript": "^1.4.3",
+        "@bitcoinerlab/miniscript": "^2.0.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
-        "bip32": "^4.0.0",
-        "bitcoinjs-lib": "^6.1.7",
-        "ecpair": "^2.1.0",
+        "bip32": "github:bitcoinjs/bip32#9e4471ddad38c2d344c1167048072f1c569a115e",
+        "bitcoinjs-lib": "^7.0.1",
+        "ecpair": "^3.0.1",
         "lodash.memoize": "^4.1.2",
-        "varuint-bitcoin": "^1.1.2"
+        "varuint-bitcoin": "^2.0.0"
       },
       "peerDependencies": {
-        "ledger-bitcoin": "^0.2.2"
+        "@ledgerhq/ledger-bitcoin": "^0.3.0"
       },
       "peerDependenciesMeta": {
-        "ledger-bitcoin": {
+        "@ledgerhq/ledger-bitcoin": {
           "optional": true
         }
       }
     },
     "node_modules/@bitcoinerlab/discovery": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/discovery/-/discovery-1.5.3.tgz",
-      "integrity": "sha512-vhINi551M2bpWuNKKSqdjfQpGKjpPtIbl9EWIzSSyM6vgeEehRYpnfYUl+56BZF6GkiVunLl2e4NPIQL77LDUw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/discovery/-/discovery-2.0.0.tgz",
+      "integrity": "sha512-acXnHOV4zTM8rz93Y9mt7pSo++10EW84o66PbAtdls+56GDNizJSYHzOyUTPeKzF79h66uR0vt8C81bJZR1njA==",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.3.4",
-        "@bitcoinerlab/explorer": "^0.4.2",
+        "@bitcoinerlab/descriptors": "^3.0.2",
+        "@bitcoinerlab/explorer": "^1.0.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@types/memoizee": "^0.4.8",
-        "bitcoinjs-lib": "^6.1.7",
+        "bitcoinjs-lib": "^7.0.1",
         "immer": "^9.0.21",
         "lodash.clonedeep": "^4.5.0",
         "memoizee": "^0.4.15",
-        "shallow-equal": "^3.1.0"
+        "shallow-equal": "^3.1.0",
+        "uint8array-tools": "^0.0.9"
       }
     },
     "node_modules/@bitcoinerlab/electrum-client": {
@@ -97,21 +148,31 @@
       }
     },
     "node_modules/@bitcoinerlab/explorer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.4.2.tgz",
-      "integrity": "sha512-lriwfjxxV7UC12ehW1I82bMvz4wbAEaYZWSZNBaYHXojutAiGTWpDolDd2AdYfkfEVZUariqXEbiv3KZ4BmUsg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-1.0.0.tgz",
+      "integrity": "sha512-pfZeu5fpWkJDvaVCqfpaxd/OJflvlV3cuJ0gkiH+TTc1a644iEfdqicADhww/83Kd1oHlu/CB+SsgNeIioCA8Q==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/electrum-client": "^1.0.4",
-        "bitcoinjs-lib": "^6.1.7"
+        "bitcoinjs-lib": "^7.0.1"
       }
     },
     "node_modules/@bitcoinerlab/miniscript": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-1.4.3.tgz",
-      "integrity": "sha512-gf7WK4dKJJJl+IgLGmkTOxXQLiCje9c9y4wTLC+cyt0tBDTiSXgsG0X8FFaXf4d+34b8B5p/EJGvRd7mEYB6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-2.0.0.tgz",
+      "integrity": "sha512-P8yyubPf6lphmIZfyD/ZbhT/umJX7zH1mKjGql7z0Qt+xuffnz2AueQqq2/01VE2rTIq80VM0oRFdJClGBYx/g==",
       "license": "MIT",
       "dependencies": {
+        "bip68": "^1.0.4"
+      }
+    },
+    "node_modules/@bitcoinerlab/miniscript-policies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript-policies/-/miniscript-policies-1.1.0.tgz",
+      "integrity": "sha512-ufbWulrnZeEFwmh7O6Yy+d8W1RP64H4u1LNEEnpYn8JQCUs4tZm39sb3BSE0h4eO5QuszU0Va8QSLa98/1/4bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/miniscript": "^2.0.0",
         "bip68": "^1.0.4"
       }
     },
@@ -823,20 +884,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jl.landabaso/btcmessage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@jl.landabaso/btcmessage/-/btcmessage-3.0.0.tgz",
-      "integrity": "sha512-JJQ6GyEFtPqltqJvT71hKsV1+oXQYp47yi2bwgHg6hYBsY83SojmC4yNYX9ag/wJOALMIWofrqRQRi+KW7IPmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bech32": "^1.1.4",
-        "bs58check": "^3.0.1",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/@ledgerhq/devices": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.10.0.tgz",
@@ -906,6 +953,160 @@
         "@ledgerhq/errors": "^6.29.0",
         "@ledgerhq/hw-transport": "6.32.0",
         "@ledgerhq/logs": "^6.14.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/ledger-bitcoin/-/ledger-bitcoin-0.3.0.tgz",
+      "integrity": "sha512-T5jV34CD+vDMMkQBONIkwf1p2hbOjDVbCkLCCTEL5BH4Zic/8jAiojvzIPFA6n7ZGlavzH7oaUVI6lWMGYHGZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bitcoinerlab/descriptors": "^1.1.1",
+        "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@ledgerhq/hw-transport": "^6.31.13",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.1.7"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/@bitcoinerlab/descriptors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-1.1.1.tgz",
+      "integrity": "sha512-AMFkbBBg9T1iWtEmWB23oADk7zaOQix6wUPLXalhTyFDjhkFXDd6pCRfto/HAdaPg/ccM4GMTVgYLee9WdYFyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/miniscript": "^1.2.1",
+        "@bitcoinerlab/secp256k1": "^1.0.5",
+        "bip32": "^4.0.0",
+        "bitcoinjs-lib": "^6.1.3",
+        "ecpair": "^2.1.0"
+      },
+      "peerDependencies": {
+        "ledger-bitcoin": "^0.2.2"
+      },
+      "peerDependenciesMeta": {
+        "ledger-bitcoin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/@bitcoinerlab/miniscript": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-1.4.3.tgz",
+      "integrity": "sha512-gf7WK4dKJJJl+IgLGmkTOxXQLiCje9c9y4wTLC+cyt0tBDTiSXgsG0X8FFaXf4d+34b8B5p/EJGvRd7mEYB6mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bip68": "^1.0.4"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/bip174": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/bip32": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
+      "integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "@scure/base": "^1.1.1",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/bitcoinjs-lib": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
+      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bip174": "^2.1.1",
+        "bs58check": "^3.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/ecpair": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
+      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.1.0",
+        "typeforce": "^1.18.0",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "<3.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/ledger-bitcoin/node_modules/wif/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/@ledgerhq/logs": {
@@ -1362,12 +1563,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
-    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1378,27 +1573,32 @@
       }
     },
     "node_modules/bip174": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
-      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
+      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
       "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bip32": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
-      "integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+      "version": "5.0.1",
+      "resolved": "git+ssh://git@github.com/bitcoinjs/bip32.git#9e4471ddad38c2d344c1167048072f1c569a115e",
+      "integrity": "sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "@scure/base": "^1.1.1",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bip32-path": {
@@ -1406,6 +1606,15 @@
       "resolved": "https://registry.npmjs.org/bip32-path/-/bip32-path-0.4.2.tgz",
       "integrity": "sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ==",
       "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/bip39": {
       "version": "3.1.0",
@@ -1441,27 +1650,53 @@
       "license": "MIT"
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.1.tgz",
+      "integrity": "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
+        "bip174": "^3.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^1.2.0",
+        "varuint-bitcoin": "^2.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "node_modules/bitcoinjs-lib/node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
       "license": "MIT"
+    },
+    "node_modules/bitcoinjs-lib/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -1806,17 +2041,26 @@
       }
     },
     "node_modules/ecpair": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
-      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-3.0.1.tgz",
+      "integrity": "sha512-uz8wMFvtdr58TLrXnAesBsoMEyY8UudLOfApcyg40XfZjP+gt1xO4cuZSIkZ8hTMTQ8+ETgt7xSIV4eM7M6VNw==",
       "license": "MIT",
       "dependencies": {
-        "randombytes": "^2.1.0",
-        "typeforce": "^1.18.0",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ecpair/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -2827,44 +3071,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/ledger-bitcoin": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.3.tgz",
-      "integrity": "sha512-sWdvMTR5CkebNlM0Mam9ROdpsD7Y4087kj4cbIaCCq8IXShCQ44vE3j0wTmt+sHp13eETgY63OWN1rkuIfMfuQ==",
-      "deprecated": "Please use @ledgerhq/ledger-bitcoin",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bitcoinerlab/descriptors": "^1.0.2",
-        "@bitcoinerlab/secp256k1": "^1.0.5",
-        "@ledgerhq/hw-transport": "^6.20.0",
-        "bip32-path": "^0.4.2",
-        "bitcoinjs-lib": "^6.1.3"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/ledger-bitcoin/node_modules/@bitcoinerlab/descriptors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-1.1.1.tgz",
-      "integrity": "sha512-AMFkbBBg9T1iWtEmWB23oADk7zaOQix6wUPLXalhTyFDjhkFXDd6pCRfto/HAdaPg/ccM4GMTVgYLee9WdYFyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@bitcoinerlab/miniscript": "^1.2.1",
-        "@bitcoinerlab/secp256k1": "^1.0.5",
-        "bip32": "^4.0.0",
-        "bitcoinjs-lib": "^6.1.3",
-        "ecpair": "^2.1.0"
-      },
-      "peerDependencies": {
-        "ledger-bitcoin": "^0.2.2"
-      },
-      "peerDependenciesMeta": {
-        "ledger-bitcoin": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3797,7 +4003,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3805,6 +4011,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/undici-types": {
@@ -3852,13 +4067,36 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/varuint-bitcoin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.1.1"
+        "uint8array-tools": "^0.0.8"
+      }
+    },
+    "node_modules/varuint-bitcoin/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/which": {
@@ -3900,41 +4138,37 @@
       }
     },
     "node_modules/wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
       "license": "MIT",
       "dependencies": {
-        "bs58check": "<3.0.0"
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/wif/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "node_modules/wif/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
       "dependencies": {
-        "base-x": "^3.0.2"
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/wif/node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "license": "MIT",
       "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "playground",
   "type": "module",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "scripts": {
     "descriptors/legacy2segwit": "tsx ./descriptors/legacy2segwit/index.ts",
     "descriptors/miniscript": "tsx ./descriptors/miniscript/index.ts",
     "descriptors/ledger": "tsx ./descriptors/ledger/index.ts",
-    "descriptors/multisig-fallback-timelock": "tsx ./descriptors/multisig-fallback-timelock/index.ts",
     "descriptors/p2a": "tsx ./descriptors/p2a/index.ts",
     "descriptors/inscriptions": "tsx ./descriptors/inscriptions/index.ts",
     "descriptors/rewind2": "tsx ./descriptors/rewind2/index.ts",
@@ -16,13 +15,15 @@
   "author": "Jose-Luis Landabaso",
   "note-on-dependecies": "@noble/hashes, create-hash and randombytes are explicitly added to address an issue in CodeSandbox where it's unable to resolve the environment correctly. CodeSandbox should be identifying a browser environment and selecting the appropriate random system functions, rather than defaulting to Node.js ones.",
   "dependencies": {
-    "@bitcoinerlab/coinselect": "^1.3.4",
-    "@bitcoinerlab/descriptors": "^2.3.6",
-    "@bitcoinerlab/discovery": "^1.5.3",
-    "@bitcoinerlab/explorer": "^0.4.2",
-    "@bitcoinerlab/miniscript": "^1.4.3",
+    "@bitcoinerlab/coinselect": "^2.0.0",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/discovery": "^2.0.0",
+    "@bitcoinerlab/explorer": "^1.0.0",
+    "@bitcoinerlab/miniscript": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
-    "@jl.landabaso/btcmessage": "^3.0.0",
+    "@bitcoinerlab/btcmessage": "^4.0.1",
+    "@ledgerhq/ledger-bitcoin": "^0.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.14",
     "@ledgerhq/hw-transport-webhid": "^6.30.9",
     "@noble/ciphers": "^2.1.1",
@@ -31,9 +32,10 @@
     "bip65": "^1.0.3",
     "create-hash": "^1.2.0",
     "fs": "^0.0.1-security",
-    "ledger-bitcoin": "^0.2.3",
     "pushdata-bitcoin": "^1.0.1",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "uint8array-tools": "^0.0.9",
+    "varuint-bitcoin": "^2.0.0"
   },
   "comment": [
     "Note to devs:",


### PR DESCRIPTION
- Upgrade the playground to the descriptors v3 / bitcoinjs-lib v7 stack (`descriptors`, `discovery`, `explorer`, `coinselect`, `miniscript`) and add `@bitcoinerlab/miniscript-policies`.
- Migrate playground code to bigint amounts and Uint8Array-first binary handling, including rewind2 and shared inscriptions internals.
- Fix repeat-run failures in `descriptors/inscriptions` by selecting spendable UTXOs from `/address/:address/utxo` instead of scanning tx history for potentially spent outputs.

## Detailed Changes

- Dependencies and runtime:
  - Replace `@jl.landabaso/btcmessage` with `@bitcoinerlab/btcmessage@^4.0.1`.
  - Replace `ledger-bitcoin` with `@ledgerhq/ledger-bitcoin`.
  - Add `uint8array-tools` and `varuint-bitcoin`.
- Miniscript policies:
  - Switch `compilePolicy` imports to `@bitcoinerlab/miniscript-policies`.
  - Await `ready` before `compilePolicy` (without top-level await, CodeSandbox-safe).
- Uint8Array / bigint migration:
  - Migrate inscriptions helpers (`descriptors/inscriptions/inscriptions.ts`, `descriptors/rewind2/inscriptions.ts`) to Uint8Array-first APIs.
  - Migrate rewind2 backup/cipher/vault serialization and recovery flow to Uint8Array-first operations.
  - Standardize tx/psbt amounts to bigint across playgrounds.
- Docs:
  - Update `README.md` with stack notes (bigint, miniscript-policies, network detection guidance).